### PR TITLE
Delivery of compatibility for Flake8 from version 4 to the latest ver…

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,12 +1,3 @@
-v1.3.0
-======
-
-Features
---------
-
-- Compatible for Flake8 from version flake8>=4. (#4)
-
-
 v1.2.2
 ======
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,12 @@
+v1.3.0
+======
+
+Features
+--------
+
+- Compatible for Flake8 from version flake8>=4. (#??)
+
+
 v1.2.2
 ======
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -4,7 +4,7 @@ v1.3.0
 Features
 --------
 
-- Compatible for Flake8 from version flake8>=4. (#??)
+- Compatible for Flake8 from version flake8>=4. (#4)
 
 
 v1.2.2

--- a/README.rst
+++ b/README.rst
@@ -1,21 +1,31 @@
-.. image:: https://img.shields.io/pypi/v/pytest-flake8.svg
+.. image:: https://img.shields.io/pypi/v/pytest-flake8.svg?label=pytest-flake8
    :target: https://pypi.org/project/pytest-flake8
+   :alt: Package
 
-.. image:: https://img.shields.io/pypi/pyversions/pytest-flake8.svg
 
-.. image:: https://github.com/coherent-oss/pytest-flake8/actions/workflows/main.yml/badge.svg
-   :target: https://github.com/coherent-oss/pytest-flake8/actions?query=workflow%3A%22tests%22
-   :alt: tests
+.. image:: https://readthedocs.org/projects/pytest-flake8/badge
+   :target: https://pytest-flake8.readthedocs.io/en/latest
+   :alt: Documentation
+
+
+.. image:: https://github.com/coherent-oss/pytest-flake8/actions/workflows/main.yml/badge.svg?label=test
+   :target: https://github.com/PyCQA/flake8/actions?query=workflow=main
+   :alt: Tests
+
+
+.. image:: https://img.shields.io/pypi/v/flake8.svg?label=flake8
+    :target: https://github.com/PyCQA/flake8
+    :alt: Flake8
+
 
 .. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json
     :target: https://github.com/astral-sh/ruff
     :alt: Ruff
 
-.. image:: https://readthedocs.org/projects/pytest-flake8/badge/?version=latest
-   :target: https://pytest-flake8.readthedocs.io/en/latest/?badge=latest
 
 .. image:: https://img.shields.io/badge/skeleton-2024-informational
    :target: https://blog.jaraco.com/skeleton
+   :alt: skeleton
 
 
 pytest plugin for efficiently checking PEP8 compliance 
@@ -24,7 +34,9 @@ pytest plugin for efficiently checking PEP8 compliance
 Usage
 -----
 
-Install it into a test environment, then run tests with the option::
+Install it into a test environment, then run tests with the option.
+
+.. code-block:: bash
 
     pytest --flake8
 
@@ -60,7 +72,51 @@ All the Flake8 tests are skipping!
 
 By design, results are cached and only changed files are checked.
 
-Run with ``pytest --cache-clear --flake8`` to bypass.
+To bypass this caching mechanism, run the following command:
+
+.. code-block:: bash
+
+    pytest --cache-clear --flake8
+
+Note to developers
+------------------
+
+Setup environment
+^^^^^^^^^^^^^^^^^
+
+Separate virtual environments(venv) should be set up.
+
+.. code-block:: bash
+
+    python3 -m venv .venv
+
+Switch to venv.
+
+.. code-block:: bash
+
+    source .venv/bin/activate
+
+Install tox
+^^^^^^^^^^^
+
+Separate virtual environments should be set up.
+
+.. code-block:: bash
+
+    pip install tox
+
+
+Run environment
+^^^^^^^^^^^^^^^
+
+Run tox.
+
+.. code-block:: bash
+
+    tox
+
+For more information, you can take a look at the `skeleton <https://blog.jaraco.com/skeleton/>`_.
+
 
 Notes
 -----

--- a/README.rst
+++ b/README.rst
@@ -1,31 +1,21 @@
-.. image:: https://img.shields.io/pypi/v/pytest-flake8.svg?label=pytest-flake8
+.. image:: https://img.shields.io/pypi/v/pytest-flake8.svg
    :target: https://pypi.org/project/pytest-flake8
-   :alt: Package
 
+.. image:: https://img.shields.io/pypi/pyversions/pytest-flake8.svg
 
-.. image:: https://readthedocs.org/projects/pytest-flake8/badge
-   :target: https://pytest-flake8.readthedocs.io/en/latest
-   :alt: Documentation
-
-
-.. image:: https://github.com/coherent-oss/pytest-flake8/actions/workflows/main.yml/badge.svg?label=test
-   :target: https://github.com/PyCQA/flake8/actions?query=workflow=main
-   :alt: Tests
-
-
-.. image:: https://img.shields.io/pypi/v/flake8.svg?label=flake8
-    :target: https://github.com/PyCQA/flake8
-    :alt: Flake8
-
+.. image:: https://github.com/coherent-oss/pytest-flake8/actions/workflows/main.yml/badge.svg
+   :target: https://github.com/coherent-oss/pytest-flake8/actions?query=workflow%3A%22tests%22
+   :alt: tests
 
 .. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json
     :target: https://github.com/astral-sh/ruff
     :alt: Ruff
 
+.. image:: https://readthedocs.org/projects/pytest-flake8/badge/?version=latest
+   :target: https://pytest-flake8.readthedocs.io/en/latest/?badge=latest
 
 .. image:: https://img.shields.io/badge/skeleton-2024-informational
    :target: https://blog.jaraco.com/skeleton
-   :alt: skeleton
 
 
 pytest plugin for efficiently checking PEP8 compliance 

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ To bypass this caching mechanism, run the following command:
 
 Run tests with [tox](https://tox.wiki) (e.g. `pipx run tox`).
 
-For more information, you can take a look at the `skeleton <https://blog.jaraco.com/skeleton/>`_.
+For more information, take a look at the `skeleton <https://blog.jaraco.com/skeleton/>`_.
 
 
 Notes

--- a/README.rst
+++ b/README.rst
@@ -78,42 +78,7 @@ To bypass this caching mechanism, run the following command:
 
     pytest --cache-clear --flake8
 
-Note to developers
-------------------
-
-Setup environment
-^^^^^^^^^^^^^^^^^
-
-Separate virtual environments(venv) should be set up.
-
-.. code-block:: bash
-
-    python3 -m venv .venv
-
-Switch to venv.
-
-.. code-block:: bash
-
-    source .venv/bin/activate
-
-Install tox
-^^^^^^^^^^^
-
-Separate virtual environments should be set up.
-
-.. code-block:: bash
-
-    pip install tox
-
-
-Run environment
-^^^^^^^^^^^^^^^
-
-Run tox.
-
-.. code-block:: bash
-
-    tox
+Run tests with [tox](https://tox.wiki) (e.g. `pipx run tox`).
 
 For more information, you can take a look at the `skeleton <https://blog.jaraco.com/skeleton/>`_.
 

--- a/newsfragments/4.feature.rst
+++ b/newsfragments/4.feature.rst
@@ -1,0 +1,1 @@
+Compatible for Flake8 from version ``flake8>=4``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-	"flake8 >= 5, < 6",
+	"flake8 >= 4.0",
 	"pytest >= 7.0",
 ]
 dynamic = ["version"]

--- a/pytest_flake8.py
+++ b/pytest_flake8.py
@@ -6,7 +6,6 @@ from contextlib import redirect_stdout, redirect_stderr
 from io import BytesIO, TextIOWrapper
 
 from flake8.main import application
-from flake8.options import config
 
 import pytest
 
@@ -223,29 +222,9 @@ def check_file(
         args += ['--show-source']
     if statistics:
         args += ['--statistics']
-    args += [str(path)]
     app = application.Application()
-    prelim_opts, remaining_args = app.parse_preliminary_options(args)
-    cfg, cfg_dir = config.load_config(
-        config=prelim_opts.config,
-        extra=prelim_opts.append_config,
-        isolated=prelim_opts.isolated,
-    )
-    app.find_plugins(
-        cfg,
-        cfg_dir,
-        enable_extensions=prelim_opts.enable_extensions,
-        require_plugins=prelim_opts.require_plugins,
-    )
-    app.register_plugin_options()
-    app.parse_configuration_and_cli(cfg, cfg_dir, remaining_args)
     if flake8ignore:
-        app.options.ignore = flake8ignore
-    app.make_formatter()  # fix this
-    app.make_guide()
-    app.make_file_checker_manager()
-    app.run_checks()
-    app.formatter.start()
-    app.report_errors()
-    app.formatter.stop()
+        args += ["--ignore", flake8ignore]
+    args += [str(path)]
+    app.run(args)
     return app.result_count

--- a/tests/test_flake8.py
+++ b/tests/test_flake8.py
@@ -2,8 +2,11 @@
 
 import pathlib
 import textwrap
+from packaging import version
 
 import pytest
+
+from flake8 import __version__ as flake8_version
 
 pytest_plugins = ("pytester",)
 
@@ -39,6 +42,10 @@ class TestIgnores:
         assert ign(tmpdir.join("a/y.py")) == "E203 E300".split()
         assert ign(tmpdir.join("a/z.py")) is None
 
+    @pytest.mark.xfail(
+        version.parse(flake8_version) >= version.parse("6.0.0"),
+        reason="Requires Flake8 version earlier than 6.0.0.",
+    )
     def test_default_flake8_ignores(self, testdir):
         testdir.makeini("""
             [pytest]


### PR DESCRIPTION
* Support for Flake8 from version >=4. The approach has been changed to ensure more stable plugin functionality. The implementation was modified too often, while the command-line interface remained largely the same. For this reason, it was decided not to rely heavily on the internal implementation or to do so minimally. This approach allowed for support of both the backward-compatible version and the new implementation of Flake8.

* Ensuring backward compatibility for tests, as changes have been introduced starting from version 6.0.0.

* The approach outlined above enables us to easily implement new features, as practically any flag can be passed to Flake8. It can be tagged with --flake8-{the-same-name-like-flake8}, through a very simple mechanism. This further demonstrates that this approach can be even more flexible. Within the plugin, we remove the prefix --flake8- and provide --{the-same-name-like-flake8} to argv. This makes it simple and easy to maintain.

* An update has also been added to the documentation for developers, as this was lacking. This could encourage others to contribute code.

* The appearance of the documentation after the changes.
https://github.com/pypros/pytest-flake8/tree/update-flake8-compat-4.x-to-latest